### PR TITLE
style: SideMenu margin 수정

### DIFF
--- a/client/src/components/SideMenu.tsx
+++ b/client/src/components/SideMenu.tsx
@@ -117,7 +117,6 @@ export default SideMenu;
 
 const Container = tw.div`
 w-[300px]
-m-6
 `;
 
 const PostContainer = tw.div`


### PR DESCRIPTION
## style: SideMenu margin 수정
- SideMenu가 사용되는 모든 페이지에서 SideMenu를 자유롭게 배치할 수 있도록 가장 바깥에 있는 div의 margin 값을 0으로 수정했습니다.